### PR TITLE
Use an empty string instead of "NORMAL" for EditBox font flags

### DIFF
--- a/alaCalendar.lua
+++ b/alaCalendar.lua
@@ -2878,7 +2878,7 @@ do	--	MAIN
 
 					local nameEdit = CreateFrame("EDITBOX", nil, manual);
 					nameEdit:SetHeight(24);
-					nameEdit:SetFont(ui_style.frameFont, ui_style.frameFontSize, "NORMAL");
+					nameEdit:SetFont(ui_style.frameFont, ui_style.frameFontSize, "");
 					nameEdit:SetAutoFocus(false);
 					nameEdit:SetJustifyH("LEFT");
 					nameEdit:Show();


### PR DESCRIPTION
It seems that the Wrath Classic 3.4.1 patch made the `flags` parameter in `EditBox:SetFont(font, size, flags);` **mandatory** and **only** accepts comma-delimited combinations of `"OUTLINE"`, `"THICKOUTLINE"` and `"MONOCHROME"`. The `"NORMAL"` flag is invalid and throws an error. This should be fixed by replacing it with an empty string.

**The [api changes of the 10.0.0 client](https://wowpedia.fandom.com/wiki/Patch_10.0.0/API_changes) also mention this:**
> Functions such as [Region:GetPoint](https://wowpedia.fandom.com/wiki/API_Region_GetPoint)() and [FontInstance:SetFont](https://wowpedia.fandom.com/wiki/API_FontInstance_SetFont)() will error in cases where nil values are supplied in-place of expected parameters.